### PR TITLE
Updated Rails dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ActiveStorage-Storj is a ruby gem that provides [Storj](https://www.storj.io/) c
 Note: [direct upload](https://guides.rubyonrails.org/active_storage_overview.html#direct-uploads) is not supported in this gem. To enable direct upload support, install [activestorage-storj-s3](https://github.com/Your-Data/activestorage-storj-s3) gem.
 
 ## Requirements
-* [Rails v7+](https://guides.rubyonrails.org/getting_started.html)
+* [Rails v6+](https://guides.rubyonrails.org/getting_started.html)
 * Install Active Storage on a Rails project.
 
     ```bash

--- a/activestorage-storj.gemspec
+++ b/activestorage-storj.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |spec|
     Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.md']
   end
 
-  spec.add_runtime_dependency 'rails', '~> 7.0', '>= 7.0.4'
+  spec.add_runtime_dependency 'rails', '~> 6.1', '>= 6.1.7'
   spec.add_runtime_dependency 'uplink-ruby', '~> 1.0'
 end


### PR DESCRIPTION
Removes the need for Rails 7.

This has been tested locally and seems to be working but will require further testing.